### PR TITLE
fix wrong conditions

### DIFF
--- a/modules/scfmDataPrep/scfmDataPrep.R
+++ b/modules/scfmDataPrep/scfmDataPrep.R
@@ -504,7 +504,17 @@ prepare_scfmDriver <- function(sim) {
 
     sim$studyAreaCalibration <- sf::st_union(sim$fireRegimePolysCalibration) %>%
       sf::st_as_sf()
-  } else if (hasSAC & !hasFRPC) {
+  } else if (hasSAC && !hasFRPC) {
+    frpc <- Cache(prepInputsFireRegimePolys,
+                  type = P(sim)$fireRegimePolysType,
+                  studyArea = sim$studyArea,
+                  destinationPath = dPath,
+                  userTags = c(cacheTags, P(sim)$fireRegimePolysType, "frpc"))
+
+    sim$fireRegimePolysCalibration <- frpc
+  }
+
+  if (hasSAC & !hasRTMC) {
 
     resRTM <- if (hasRTM) {
       res(sim$rasterToMatch)
@@ -515,14 +525,6 @@ prepare_scfmDriver <- function(sim) {
     sim$rasterToMatchCalibration <- terra::rast(terra::vect(sim$studyAreaCalibration),
                                                 res = resRTM,
                                                 vals = 1)
-   } else if (hasSAC && !hasFRPC) {
-    frpc <- Cache(prepInputsFireRegimePolys,
-                  type = P(sim)$fireRegimePolysType,
-                  studyArea = sim$studyArea,
-                  destinationPath = dPath,
-                  userTags = c(cacheTags, P(sim)$fireRegimePolysType, "frpc"))
-
-    sim$fireRegimePolysCalibration <- frpc
   }
 
   if (!hasFRP) {

--- a/modules/scfmDataPrep/scfmDataPrep.R
+++ b/modules/scfmDataPrep/scfmDataPrep.R
@@ -507,7 +507,7 @@ prepare_scfmDriver <- function(sim) {
   } else if (hasSAC && !hasFRPC) {
     frpc <- Cache(prepInputsFireRegimePolys,
                   type = P(sim)$fireRegimePolysType,
-                  studyArea = sim$studyArea,
+                  studyArea = sim$studyAreaCalibration,
                   destinationPath = dPath,
                   userTags = c(cacheTags, P(sim)$fireRegimePolysType, "frpc"))
 


### PR DESCRIPTION
There seems to be an error that got introduced in the logic in `.inputObjects`.

There was a condition when there is `studyAreaCalibration`, but no `fireRegimePolysCalibration` which was creating `rasterToMatchCalibration`. As a byproduct, it was skipping the step that actually created `fireRegimePolysCalibration` from `studyAreaCalibration`.

